### PR TITLE
Change crypto- lib used in Python due to being EOL and not working after 3.5

### DIFF
--- a/python3/requirements.txt
+++ b/python3/requirements.txt
@@ -1,1 +1,1 @@
-pycrypto>=2.6.1
+cryptography>=2.9.2,<3.0.0

--- a/python3/test_program.py
+++ b/python3/test_program.py
@@ -27,8 +27,9 @@ import socket
 import ssl
 import sys
 import time
-from Crypto.PublicKey import RSA
-from Crypto.Cipher import PKCS1_v1_5
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 from multiprocessing import Process
 from urllib.parse import urlencode
 
@@ -56,14 +57,13 @@ def get_hash(username, password, public_key_filename):
     # Need local copy of public key for NEXT API in PEM format
 
     try:
-        public_key_file_handler = open(public_key_filename).read()
+        public_key_file_handler = open(public_key_filename, "rb").read()
     except IOError:
         print("Could not find the following file: ",
               "\"", public_key_filename, "\"", sep="")
         sys.exit()
-    rsa_key = RSA.importKey(public_key_file_handler)
-    cipher_rsa = PKCS1_v1_5.new(rsa_key)
-    encrypted_hash = cipher_rsa.encrypt(auth_val)
+    rsa_key = serialization.load_pem_public_key(public_key_file_handler, backend=default_backend())
+    encrypted_hash = rsa_key.encrypt(auth_val, padding.PKCS1v15())
     encoded_hash = base64.b64encode(encrypted_hash)
 
     return encoded_hash


### PR DESCRIPTION
Minor change, but since most OS nowadays comes with Python 3.7 or later.
E.g. Ubuntu does not have 3.5 in their repos anymore.